### PR TITLE
feat: Added actionSignVc mutation

### DIFF
--- a/packages/daf-cli/src/graphql.ts
+++ b/packages/daf-cli/src/graphql.ts
@@ -2,7 +2,7 @@ import { ApolloServer } from 'apollo-server'
 import program from 'commander'
 import * as Daf from 'daf-core'
 import * as W3c from 'daf-w3c'
-import * as DIDComm from 'daf-did-comm'
+import * as TG from 'daf-trust-graph'
 import { Gql as DataGql } from 'daf-data-store'
 import merge from 'lodash.merge'
 import { core, dataStore } from './setup'
@@ -19,14 +19,14 @@ program
         Daf.Gql.Core.typeDefs,
         Daf.Gql.IdentityManager.typeDefs,
         DataGql.typeDefs,
-        DIDComm.Gql.typeDefs,
+        TG.Gql.typeDefs,
         W3c.Gql.typeDefs,
       ],
       resolvers: merge(
         Daf.Gql.Core.resolvers,
         Daf.Gql.IdentityManager.resolvers,
         DataGql.resolvers,
-        DIDComm.Gql.resolvers,
+        TG.Gql.resolvers,
         W3c.Gql.resolvers,
       ),
       context: () => ({ dataStore, core }),

--- a/packages/daf-trust-graph/src/graphql.ts
+++ b/packages/daf-trust-graph/src/graphql.ts
@@ -1,0 +1,37 @@
+import { Core } from 'daf-core'
+import { ActionTypes } from './action-handler'
+
+interface Context {
+  core: Core
+}
+
+const actionSendJwt = async (
+  _: any,
+  args: {
+    from: string
+    to: string
+    jwt: string
+  },
+  ctx: Context,
+) => {
+  return await ctx.core.handleAction({
+    type: ActionTypes.sendJwt,
+    data: {
+      from: args.from,
+      to: args.to,
+      jwt: args.jwt,
+    },
+  })
+}
+
+export const resolvers = {
+  Mutation: {
+    actionSendJwt,
+  },
+}
+
+export const typeDefs = `
+  extend type Mutation {
+    actionSendJwt(from: String!, to: String!, jwt: String!): Boolean
+  }
+`

--- a/packages/daf-trust-graph/src/index.ts
+++ b/packages/daf-trust-graph/src/index.ts
@@ -1,2 +1,4 @@
 export { TrustGraphServiceController } from './service-controller'
 export { ActionHandler, ActionSendJWT, ActionTypes } from './action-handler'
+import * as Gql from './graphql'
+export { Gql }

--- a/packages/daf-w3c/src/graphql.ts
+++ b/packages/daf-w3c/src/graphql.ts
@@ -1,25 +1,44 @@
 import { Core } from 'daf-core'
-import { ActionTypes } from './action-handler'
+import { ActionTypes, ActionSignW3cVc } from './action-handler'
+import { PresentationPayload, VerifiableCredentialPayload, VC } from 'did-jwt-vc/src/types'
 
 interface Context {
   core: Core
 }
 
+interface VCInput extends VC {
+  context: [string]
+}
+
+interface VerifiableCredentialInput extends VerifiableCredentialPayload {
+  vc: VCInput
+}
+
 const actionSignVc = async (
   _: any,
   args: {
-    from: string
-    to: string
+    did: string
+    data: VerifiableCredentialInput
   },
   ctx: Context,
 ) => {
+  const { data } = args
+  const payload: VerifiableCredentialPayload = {
+    sub: data.sub,
+    nbf: data.nbf,
+    jti: data.jti,
+    aud: data.aud,
+    vc: {
+      type: data.vc.type,
+      '@context': data.vc.context,
+      credentialSubject: data.vc.credentialSubject,
+    },
+  }
   return await ctx.core.handleAction({
     type: ActionTypes.signVc,
-    data: {
-      from: args.from,
-      to: args.to,
-    },
-  })
+    did: args.did,
+    data: payload,
+  } as ActionSignW3cVc)
 }
 
 export const resolvers = {
@@ -29,7 +48,24 @@ export const resolvers = {
 }
 
 export const typeDefs = `
+  scalar CredentialSubject
+
+  input VC {
+    context: [String]!
+    type: [String]!
+    credentialSubject: CredentialSubject!
+  }
+
+  input VerifiableCredentialInput {
+    sub: String!
+    nbf: Int
+    aud: String
+    exp: Int
+    jti: String
+    vc: VC
+  }
+
   extend type Mutation {
-    actionSignVc(from: String!, to: String!): Boolean
+    actionSignVc(did: String!, data: VerifiableCredentialInput!): String
   }
 `


### PR DESCRIPTION
Here are queries that I was using to test this:

```graphql
mutation sign {
  actionSignVc(
    did: "did:ethr:0x2296f523a23d9813501b51b86f99227d4f55ff1f",
    data:{
      sub: "did:ethr:0xe6ab9e10aee1f9571901f758bb82e9ba3a41b64f",
      vc: {
        context: ["https://www.w3.org/2018/credentials/v1"],
        type: ["VerifiableCredential"],
        credentialSubject: {
          name: "Simonas"
        }
      }
    }
  )
}

mutation send {
  actionSendJwt (
    from: "did:ethr:0x2296f523a23d9813501b51b86f99227d4f55ff1f",
    to: "did:ethr:0xe6ab9e10aee1f9571901f758bb82e9ba3a41b64f",
    jwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzQ2ODY4NjAsInN1YiI6ImRpZDpldGhyOjB4ZTZhYjllMTBhZWUxZjk1NzE5MDFmNzU4YmI4MmU5YmEzYTQxYjY0ZiIsInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiXSwiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiXSwiY3JlZGVudGlhbFN1YmplY3QiOnsibmFtZSI6IlNpbW9uYXMifX0sImlzcyI6ImRpZDpldGhyOjB4MjI5NmY1MjNhMjNkOTgxMzUwMWI1MWI4NmY5OTIyN2Q0ZjU1ZmYxZiJ9.VL6vTrmmODdF2H7Na5oED_1-zPTyu65bqscr9YxkutWrGNVgJOQglFemgrnTzrEvQ0mzrpgDZPiZNbKzkaX-MAA"
	)
}
```