### PR TITLE
File-system IdentityController for nacl-did

### DIFF
--- a/packages/daf-cli/package.json
+++ b/packages/daf-cli/package.json
@@ -21,6 +21,7 @@
     "daf-did-comm": "^1.4.1",
     "daf-did-jwt": "^1.4.1",
     "daf-ethr-did-fs": "^1.4.1",
+    "daf-nacl-did-fs": "^1.4.1",
     "daf-node-sqlite3": "^1.5.0",
     "daf-resolver": "^1.1.0",
     "daf-resolver-universal": "^1.1.0",

--- a/packages/daf-cli/src/setup.ts
+++ b/packages/daf-cli/src/setup.ts
@@ -4,6 +4,7 @@ import { DafUniversalResolver } from 'daf-resolver-universal'
 import * as Daf from 'daf-core'
 import * as DidJwt from 'daf-did-jwt'
 import { EthrDidFsController } from 'daf-ethr-did-fs'
+import { NaclDidFsController } from 'daf-nacl-did-fs'
 
 import * as W3c from 'daf-w3c'
 import * as SD from 'daf-selective-disclosure'
@@ -21,7 +22,8 @@ const debug = Debug('daf:cli')
 
 const defaultPath = process.env.HOME + '/.daf'
 
-const identityStoreFilename = process.env.DAF_IDENTITY_STORE ?? defaultPath + '/identity-store.json'
+const ethrIdentityStoreFilename = process.env.DAF_IDENTITY_STORE ?? defaultPath + '/identity-store-ethr.json'
+const naclIdentityStoreFilename = process.env.DAF_IDENTITY_STORE ?? defaultPath + '/identity-store-nacl.json'
 const dataStoreFilename = process.env.DAF_DATA_STORE ?? defaultPath + '/data-store-cli.sqlite3'
 const infuraProjectId = process.env.DAF_INFURA_ID ?? '5ffc47f65c4042ce847ef66a3fa70d4c'
 
@@ -47,7 +49,10 @@ if (process.env.DAF_TG_URI) TG.ServiceController.defaultUri = process.env.DAF_TG
 if (process.env.DAF_TG_WSURI) TG.ServiceController.defaultWsUri = process.env.DAF_TG_WSURI
 TG.ServiceController.webSocketImpl = ws
 
-const identityControllers = [new EthrDidFsController(identityStoreFilename)]
+const identityControllers = [
+  new EthrDidFsController(ethrIdentityStoreFilename),
+  new NaclDidFsController(naclIdentityStoreFilename),
+]
 const serviceControllers = [TG.ServiceController]
 
 const messageValidator = new DBG.MessageValidator()

--- a/packages/daf-cli/tsconfig.json
+++ b/packages/daf-cli/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../daf-did-comm" },
     { "path": "../daf-did-jwt" },
     { "path": "../daf-ethr-did-fs" },
+    { "path": "../daf-nacl-did-fs" },
     { "path": "../daf-node-sqlite3" },
     { "path": "../daf-resolver" },
     { "path": "../daf-resolver-universal" },

--- a/packages/daf-nacl-did-fs/CHANGELOG.md
+++ b/packages/daf-nacl-did-fs/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/daf-nacl-did-fs/LICENSE
+++ b/packages/daf-nacl-did-fs/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/daf-nacl-did-fs/README.md
+++ b/packages/daf-nacl-did-fs/README.md
@@ -1,0 +1,1 @@
+# DAF nacl-did fs identity controller

--- a/packages/daf-nacl-did-fs/package.json
+++ b/packages/daf-nacl-did-fs/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "daf-nacl-did-fs",
+  "description": "DAF nacl-did fs identity controller",
+  "version": "1.4.1",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "daf-core": "^1.4.1",
+    "debug": "^4.1.1",
+    "nacl-did": "^1.0.1"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.5",
+    "typescript": "^3.7.2"
+  },
+  "files": [
+    "build/**/*",
+    "src/**/*",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": "git@github.com:uport-project/daf.git",
+  "author": "Simonas Karuzas <simonas.karuzas@consensys.net>",
+  "license": "Apache-2.0",
+  "keywords": [],
+  "gitHead": "ec317e0f10cffe731648a8c2d8f58def3d3c85ff"
+}

--- a/packages/daf-nacl-did-fs/src/__tests__/default.test.ts
+++ b/packages/daf-nacl-did-fs/src/__tests__/default.test.ts
@@ -1,0 +1,6 @@
+describe('daf-nacl-did-fs', () => {
+  const a = 100
+  it('should run a dummy test', () => {
+    expect(a).toEqual(100)
+  })
+})

--- a/packages/daf-nacl-did-fs/src/identity-controller.ts
+++ b/packages/daf-nacl-did-fs/src/identity-controller.ts
@@ -1,0 +1,104 @@
+import { IdentityController, Issuer } from 'daf-core'
+import { createIdentity, loadIdentity, SerializableNaCLIdentity } from 'nacl-did'
+const fs = require('fs')
+import Debug from 'debug'
+const debug = Debug('daf:nacl-did-fs:identity-controller')
+
+interface FileContents {
+  identities: SerializableNaCLIdentity[]
+}
+
+export class NaclDidFsController implements IdentityController {
+  public type = 'nacl-did-fs'
+  private fileName: string
+
+  constructor(fileName: string) {
+    this.fileName = fileName
+  }
+
+  private readFromFile(): FileContents {
+    try {
+      const raw = fs.readFileSync(this.fileName)
+      return JSON.parse(raw) as FileContents
+    } catch (e) {
+      return { identities: [] }
+    }
+  }
+
+  private writeToFile(json: FileContents) {
+    return fs.writeFileSync(this.fileName, JSON.stringify(json))
+  }
+
+  private issuerFromIdentity(identity: SerializableNaCLIdentity): Issuer {
+    const naclId = loadIdentity(identity)
+    const issuer: Issuer = {
+      did: naclId.did,
+      // TODO: Fix. Proposal below, needs to handle Uint8Array.
+      signer: s => Promise.resolve(s),
+      //signer: data => Promise.resolve(naclId.sign(data).signature), // FIX
+      type: this.type,
+      ethereumAddress: undefined, // TODO: what should we do here?
+    }
+    return issuer
+  }
+
+  async listDids() {
+    const { identities } = this.readFromFile()
+    return identities.map(identity => identity.did)
+  }
+
+  async listIssuers() {
+    const { identities } = this.readFromFile()
+    return identities.map(this.issuerFromIdentity.bind(this)) as Issuer[]
+  }
+
+  async create() {
+    const { identities } = this.readFromFile()
+    const naclId = createIdentity()
+
+    this.writeToFile({
+      identities: [...identities, naclId.toJSON()],
+    })
+
+    debug('Created', naclId.did)
+
+    return naclId.did
+  }
+
+  async delete(did: string) {
+    const { identities } = this.readFromFile()
+
+    if (!identities.find(identity => identity.did == did)) {
+      return false
+    }
+
+    const filteredIdentities = identities.filter(identity => identity.did != did)
+
+    this.writeToFile({ identities: filteredIdentities })
+
+    debug('Deleted', did)
+
+    return true
+  }
+
+  async issuer(did: string) {
+    const { identities } = this.readFromFile()
+
+    const identity = identities.find(identity => identity.did == did)
+    if (!identity) {
+      return Promise.reject('Did not found: ' + did)
+    }
+
+    return this.issuerFromIdentity(identity)
+  }
+
+  async export(did: string) {
+    const { identities } = this.readFromFile()
+
+    const identity = identities.find(identity => identity.did == did)
+    if (!identity) {
+      return Promise.reject('Did not found: ' + did)
+    }
+    return identity.privateKey
+  }
+}

--- a/packages/daf-nacl-did-fs/src/index.ts
+++ b/packages/daf-nacl-did-fs/src/index.ts
@@ -1,0 +1,1 @@
+export { NaclDidFsController } from './identity-controller'

--- a/packages/daf-nacl-did-fs/tsconfig.json
+++ b/packages/daf-nacl-did-fs/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.settings.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "references": [{ "path": "../daf-core" }]
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "daf-ethr-did-local-storage" },
     { "path": "daf-ethr-did-metamask" },
     { "path": "daf-ethr-did-react-native" },
+    { "path": "daf-nacl-did-fs" },
     { "path": "daf-node-sqlite3" },
     { "path": "daf-node-sqlite3" },
     { "path": "daf-random" },


### PR DESCRIPTION
First implementation of Identitycontroller for nacl-did based on the existing Ethr Identity Controller.
*Do not merge* until the following issue is resolved:

- Signer Interface needs to be generalized finish integration. Dependency on https://github.com/uport-project/daf/issues/51
- See marked //TODOs. 