### PR TITLE
feat: print raw JWT if no QR-Code output is requested.

### DIFF
--- a/packages/daf-cli/src/credential.ts
+++ b/packages/daf-cli/src/credential.ts
@@ -84,6 +84,8 @@ program
 
     if (cmd.qrcode) {
       qrcode.generate(jwt)
+    } else {
+      console.log(`jwt: ${jwt}`)
     }
   })
 
@@ -228,6 +230,8 @@ program
 
       if (cmd.qrcode) {
         qrcode.generate(jwt)
+      } else {
+        console.log(`jwt: ${jwt}`)
       }
     }
   })

--- a/packages/daf-cli/src/sdr.ts
+++ b/packages/daf-cli/src/sdr.ts
@@ -116,5 +116,7 @@ program
 
     if (cmd.qrcode) {
       qrcode.generate(jwt)
+    } else {
+      console.log(`jwt: ${jwt}`)
     }
   })


### PR DESCRIPTION
Hey Simonas,

it would be helpful if `daf-cli` would be able to print the raw jwt if the qr-code was NOT requested for SDR and Credentials module.

Here's a small PR for that.