### PR TITLE
IdentityController: optional ttl and gas with default values

### DIFF
--- a/docs/api/daf-core.abstractidentitycontroller.addpublickey.md
+++ b/docs/api/daf-core.abstractidentitycontroller.addpublickey.md
@@ -7,7 +7,7 @@
 <b>Signature:</b>
 
 ```typescript
-addPublicKey(type: string, proofPurpose?: string[]): Promise<string>;
+addPublicKey(type: string, proofPurpose?: string[], ttl?: number, gas?: number): Promise<string>;
 ```
 
 ## Parameters
@@ -16,6 +16,8 @@ addPublicKey(type: string, proofPurpose?: string[]): Promise<string>;
 | ------------ | --------------------- | ----------- |
 | type         | <code>string</code>   |             |
 | proofPurpose | <code>string[]</code> |             |
+| ttl          | <code>number</code>   |             |
+| gas          | <code>number</code>   |             |
 
 <b>Returns:</b>
 

--- a/docs/api/daf-core.abstractidentitycontroller.addservice.md
+++ b/docs/api/daf-core.abstractidentitycontroller.addservice.md
@@ -7,7 +7,7 @@
 <b>Signature:</b>
 
 ```typescript
-addService(service: ServiceEndpoint): Promise<any>;
+addService(service: ServiceEndpoint, ttl?: number, gas?: number): Promise<any>;
 ```
 
 ## Parameters
@@ -15,6 +15,8 @@ addService(service: ServiceEndpoint): Promise<any>;
 | Parameter | Type                         | Description |
 | --------- | ---------------------------- | ----------- |
 | service   | <code>ServiceEndpoint</code> |             |
+| ttl       | <code>number</code>          |             |
+| gas       | <code>number</code>          |             |
 
 <b>Returns:</b>
 

--- a/docs/api/daf-core.abstractidentitycontroller.md
+++ b/docs/api/daf-core.abstractidentitycontroller.md
@@ -12,9 +12,9 @@ export declare abstract class AbstractIdentityController
 
 ## Methods
 
-| Method                                                                                    | Modifiers | Description |
-| ----------------------------------------------------------------------------------------- | --------- | ----------- |
-| [addPublicKey(type, proofPurpose)](./daf-core.abstractidentitycontroller.addpublickey.md) |           |             |
-| [addService(service)](./daf-core.abstractidentitycontroller.addservice.md)                |           |             |
-| [removePublicKey(keyId)](./daf-core.abstractidentitycontroller.removepublickey.md)        |           |             |
-| [removeService(service)](./daf-core.abstractidentitycontroller.removeservice.md)          |           |             |
+| Method                                                                                              | Modifiers | Description |
+| --------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| [addPublicKey(type, proofPurpose, ttl, gas)](./daf-core.abstractidentitycontroller.addpublickey.md) |           |             |
+| [addService(service, ttl, gas)](./daf-core.abstractidentitycontroller.addservice.md)                |           |             |
+| [removePublicKey(keyId)](./daf-core.abstractidentitycontroller.removepublickey.md)                  |           |             |
+| [removeService(service)](./daf-core.abstractidentitycontroller.removeservice.md)                    |           |             |

--- a/packages/daf-core/src/identity/abstract-identity-controller.ts
+++ b/packages/daf-core/src/identity/abstract-identity-controller.ts
@@ -6,7 +6,7 @@ export interface ServiceEndpoint {
 }
 
 export abstract class AbstractIdentityController {
-  addPublicKey(type: string, proofPurpose?: string[]): Promise<string> {
+  addPublicKey(type: string, proofPurpose?: string[], ttl?: number, gas?: number): Promise<string> {
     return Promise.reject('Method addPublicKey not implemented')
   }
 
@@ -14,7 +14,7 @@ export abstract class AbstractIdentityController {
     return Promise.reject('Method removePublicKey not implemented')
   }
 
-  addService(service: ServiceEndpoint): Promise<any> {
+  addService(service: ServiceEndpoint, ttl?: number, gas?: number): Promise<any> {
     return Promise.reject('Method addService not implemented')
   }
 

--- a/packages/daf-ethr-did/src/identity-controller.ts
+++ b/packages/daf-ethr-did/src/identity-controller.ts
@@ -3,6 +3,9 @@ const EthrDID = require('ethr-did')
 import Debug from 'debug'
 const debug = Debug('daf:ethr-did:identity-controller')
 
+const DEFAULT_TTL = 60 * 60 * 24 * 30 * 12
+const DEFAULT_GAS = 100000
+
 export class IdentityController extends AbstractIdentityController {
   private did: string
   private kms: AbstractKeyManagementSystem
@@ -25,13 +28,12 @@ export class IdentityController extends AbstractIdentityController {
     this.address = options.address
   }
 
-  async addService(service: { id: string; type: string; serviceEndpoint: string }): Promise<any> {
+  async addService(service: { id: string; type: string; serviceEndpoint: string },
+                    ttl: number=DEFAULT_TTL, gas: number=DEFAULT_GAS): Promise<any> {
     const ethrDid = new EthrDID({ address: this.address, provider: this.web3Provider })
 
     const attribute = 'did/svc/' + service.type
     const value = service.serviceEndpoint
-    const ttl = 60 * 60 * 24 * 30 * 12
-    const gas = 100000
     debug('ethrDid.setAttribute', { attribute, value, ttl, gas })
     try {
       const txHash = await ethrDid.setAttribute(attribute, value, ttl, gas)
@@ -43,7 +45,8 @@ export class IdentityController extends AbstractIdentityController {
     }
   }
 
-  async addPublicKey(type: 'Ed25519' | 'Secp256k1', proofPurpose?: string[]): Promise<any> {
+  async addPublicKey(type: 'Ed25519' | 'Secp256k1', proofPurpose?: string[],
+                      ttl: number=DEFAULT_TTL, gas: number=DEFAULT_GAS): Promise<any> {
     const serializedIdentity = await this.identityStore.get(this.did)
     const ethrDid = new EthrDID({ address: this.address, provider: this.web3Provider })
 
@@ -52,8 +55,6 @@ export class IdentityController extends AbstractIdentityController {
     const usg = 'veriKey'
     const attribute = 'did/pub/' + type + '/' + usg + '/hex'
     const value = '0x' + key.serialized.publicKeyHex
-    const ttl = 60 * 60 * 24 * 30 * 12
-    const gas = 100000
     debug('ethrDid.setAttribute', { attribute, value, ttl, gas })
 
     try {


### PR DESCRIPTION
I would suggest to have `ttl` and `gas` as optional parameters in case someone would like to specify other values for them