### PR TITLE
fix(deps): enable verification of ES256K signatures with default did:ethr: docs

### DIFF
--- a/packages/daf-did-jwt/package.json
+++ b/packages/daf-did-jwt/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "daf-core": "^3.4.2",
     "debug": "^4.1.1",
-    "did-jwt": "^4.0.0",
+    "did-jwt": "4.2.0",
     "did-resolver": "^1.1.0"
   },
   "devDependencies": {

--- a/packages/daf-libsodium/package.json
+++ b/packages/daf-libsodium/package.json
@@ -11,7 +11,7 @@
     "base-58": "^0.0.1",
     "daf-core": "^3.4.2",
     "debug": "^4.1.1",
-    "did-jwt": "^4.0.0",
+    "did-jwt": "4.2.0",
     "elliptic": "^6.5.2",
     "ethjs-signer": "^0.1.1",
     "libsodium-wrappers": "^0.7.6"

--- a/packages/daf-react-native-libsodium/package.json
+++ b/packages/daf-react-native-libsodium/package.json
@@ -11,7 +11,7 @@
     "base-58": "^0.0.1",
     "daf-core": "^3.4.2",
     "debug": "^4.1.1",
-    "did-jwt": "^4.0.0",
+    "did-jwt": "4.2.0",
     "elliptic": "^6.5.2",
     "ethjs-signer": "^0.1.1"
   },

--- a/packages/daf-selective-disclosure/package.json
+++ b/packages/daf-selective-disclosure/package.json
@@ -13,7 +13,7 @@
     "daf-data-store": "^3.4.2",
     "daf-did-jwt": "^3.4.2",
     "debug": "^4.1.1",
-    "did-jwt": "^4.0.0"
+    "did-jwt": "4.2.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/packages/daf-trust-graph/package.json
+++ b/packages/daf-trust-graph/package.json
@@ -17,7 +17,7 @@
     "cross-fetch": "^3.0.4",
     "daf-core": "^3.4.2",
     "debug": "^4.1.1",
-    "did-jwt": "^4.0.0",
+    "did-jwt": "4.2.0",
     "graphql": "^14.0.0",
     "graphql-tag": "^2.10.1",
     "subscriptions-transport-ws": "^0.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3936,6 +3936,21 @@ did-jwt-vc@^0.1.3:
   dependencies:
     did-jwt "^3.0.0"
 
+did-jwt@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-4.2.0.tgz#38798716ba646191fd512d280df39c99da1b7ec8"
+  integrity sha512-fuC/0DCmu1mM1gc1vdrtdCX5Rmj2c/OPxCVU5nnYsLN1eqRjui+7z3MjGOfSqSdh/rWQZrQfzliS+FyOI6jOsA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@stablelib/utf8" "^0.10.1"
+    buffer "^5.2.1"
+    did-resolver "^1.0.0"
+    elliptic "^6.4.0"
+    js-sha256 "^0.9.0"
+    js-sha3 "^0.8.0"
+    tweetnacl "^1.0.1"
+    uport-base64url "3.0.2-alpha.0"
+
 did-jwt@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-0.1.3.tgz#0d23c74ed4e5188e9c10fb85b5e8c3e42ecb9da9"
@@ -3955,21 +3970,6 @@ did-jwt@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-3.0.0.tgz#5e11f1d6e5c9e2d8bdcba0d391f1fcec7c58a07d"
   integrity sha512-/zHwoUN6eA+zTpV4HjTVMrVXOGfcfh8le4s9ibvv53ammMwdPj3RnLpw539JtnHm7dCXLq7rpjBkoX3lbbxoPQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    "@stablelib/utf8" "^0.10.1"
-    buffer "^5.2.1"
-    did-resolver "^1.0.0"
-    elliptic "^6.4.0"
-    js-sha256 "^0.9.0"
-    js-sha3 "^0.8.0"
-    tweetnacl "^1.0.1"
-    uport-base64url "3.0.2-alpha.0"
-
-did-jwt@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-4.0.0.tgz#243bf1da82d5a67ce4d742afb10f5f63169f5b4e"
-  integrity sha512-esCR3mVngXQhV2Q1NjdVdkzirgxHpuzqnn4Ga4mNwXFbvYNj9fHD2/oTJXaLZeXxImJmHJQwFEr0TPMoQAlcwg==
   dependencies:
     "@babel/runtime" "^7.3.1"
     "@stablelib/utf8" "^0.10.1"


### PR DESCRIPTION
After this change, there is no longer any need to use ES256K-R from DAF

bump did-jwt
  * daf-did-jwt: 4.2.0
  * daf-libsodium: ^4.0.0 → 4.2.0
  * daf-react-native-libsodium: ^4.0.0 → 4.2.0
  * daf-selective-disclosure: ^4.0.0 → 4.2.0
  * daf-trust-graph: ^4.0.0 → 4.2.0