### PR TITLE
feat: Support many audience members in a presentation and feat: Support many audience members in a presentation

### DIFF
--- a/packages/daf-core/src/__tests__/entities.test.ts
+++ b/packages/daf-core/src/__tests__/entities.test.ts
@@ -4,7 +4,7 @@ import { Entities } from '../index'
 import { blake2bHex } from 'blakejs'
 import fs from 'fs'
 
-describe('daf-core', () => {
+describe('daf-core entities', () => {
   let connection: Connection
   const databaseFile = './test-db.sqlite'
 
@@ -97,7 +97,7 @@ describe('daf-core', () => {
 
     const vp = new Presentation()
     vp.issuer = id1
-    vp.audience = id2
+    vp.audience = [id2]
     vp.issuanceDate = new Date()
     vp.context = ['https://www.w3.org/2018/credentials/v1323', 'https://www.w3.org/2020/demo/4342323']
     vp.type = ['VerifiablePresentation', 'PublicProfile']

--- a/packages/daf-core/src/agent.ts
+++ b/packages/daf-core/src/agent.ts
@@ -9,6 +9,7 @@ import { ActionHandler } from './action/action-handler'
 import { Action } from './types'
 import { Message, MetaData } from './entities/message'
 import { Connection } from 'typeorm'
+import { verifyJWT } from 'did-jwt'
 
 import Debug from 'debug'
 const debug = Debug('daf:agent')
@@ -34,6 +35,7 @@ interface Config {
 
 export class Agent extends EventEmitter {
   readonly dbConnection: Promise<Connection>
+  readonly authentication?: boolean
   public identityManager: IdentityManager
   public didResolver: Resolver
   private serviceManager: ServiceManager

--- a/packages/daf-core/src/agent.ts
+++ b/packages/daf-core/src/agent.ts
@@ -9,7 +9,6 @@ import { ActionHandler } from './action/action-handler'
 import { Action } from './types'
 import { Message, MetaData } from './entities/message'
 import { Connection } from 'typeorm'
-import { verifyJWT } from 'did-jwt'
 
 import Debug from 'debug'
 const debug = Debug('daf:agent')
@@ -35,7 +34,6 @@ interface Config {
 
 export class Agent extends EventEmitter {
   readonly dbConnection: Promise<Connection>
-  readonly authentication?: boolean
   public identityManager: IdentityManager
   public didResolver: Resolver
   private serviceManager: ServiceManager

--- a/packages/daf-core/src/entities/identity.ts
+++ b/packages/daf-core/src/entities/identity.ts
@@ -4,6 +4,7 @@ import {
   PrimaryColumn,
   BaseEntity,
   OneToMany,
+  ManyToMany,
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm'
@@ -55,7 +56,7 @@ export class Identity extends BaseEntity {
   )
   issuedPresentations: Presentation[]
 
-  @OneToMany(
+  @ManyToMany(
     type => Presentation,
     presentation => presentation.audience,
   )

--- a/packages/daf-core/src/entities/message.ts
+++ b/packages/daf-core/src/entities/message.ts
@@ -67,6 +67,9 @@ export class Message extends BaseEntity {
   @Column('simple-json', { nullable: true })
   data?: any
 
+  @Column({ nullable: true })
+  visibility?: string
+
   // https://github.com/decentralized-identity/didcomm-messaging/blob/41f35f992275dd71d459504d14eb8d70b4185533/jwm.md#jwm-profile
 
   @Column('simple-array', { nullable: true })

--- a/packages/daf-core/src/entities/presentation.ts
+++ b/packages/daf-core/src/entities/presentation.ts
@@ -40,7 +40,7 @@ export class Presentation extends BaseEntity {
   )
   issuer: Identity
 
-  @ManyToOne(
+  @ManyToMany(
     type => Identity,
     identity => identity.receivedPresentations,
     {
@@ -48,7 +48,8 @@ export class Presentation extends BaseEntity {
       eager: true,
     },
   )
-  audience: Identity
+  @JoinTable()
+  audience: Identity[]
 
   @Column({ nullable: true })
   id?: String

--- a/packages/daf-core/src/graphql/graphql-core.ts
+++ b/packages/daf-core/src/graphql/graphql-core.ts
@@ -23,11 +23,7 @@ import { Identity } from '../entities/identity'
 
 export interface Context {
   agent: Agent
-<<<<<<< HEAD
   authenticatedDid?: string
-=======
-  authenticatedDid?: Promise<string>
->>>>>>> feat: Optionally add permissions to gql resolvers
 }
 
 export interface Order {
@@ -196,7 +192,7 @@ const presentations = async (_: any, args: FindArgs, ctx: Context) => {
   if (ctx.authenticatedDid) {
     qb = qb.andWhere(
       new Brackets(qb => {
-        qb.where('presentation.audience = :ident', {
+        qb.where('audience.did = :ident', {
           ident: ctx.authenticatedDid,
         }).orWhere('presentation.issuer = :ident', { ident: ctx.authenticatedDid })
       }),
@@ -217,7 +213,7 @@ const presentationsCount = async (_: any, args: FindArgs, ctx: Context) => {
   if (ctx.authenticatedDid) {
     qb = qb.andWhere(
       new Brackets(qb => {
-        qb.where('presentation.audience = :ident', {
+        qb.where('audience.did = :ident', {
           ident: ctx.authenticatedDid,
         }).orWhere('presentation.issuer = :ident', { ident: ctx.authenticatedDid })
       }),
@@ -363,7 +359,7 @@ export const resolvers = {
       if (ctx.authenticatedDid) {
         qb = qb.andWhere(
           new Brackets(qb => {
-            qb.where('presentation.audience = :ident', {
+            qb.where('audience.did = :ident', {
               ident: ctx.authenticatedDid,
             }).orWhere('presentation.issuer = :ident', { ident: ctx.authenticatedDid })
           }),
@@ -719,7 +715,7 @@ export const typeDefs = `
     id: String
     raw: String!
     issuer: Identity!
-    audience: Identity!
+    audience: [Identity]!
     issuanceDate: Date!
     expirationDate: Date
     context: [String]

--- a/packages/daf-core/src/graphql/graphql-core.ts
+++ b/packages/daf-core/src/graphql/graphql-core.ts
@@ -23,7 +23,11 @@ import { Identity } from '../entities/identity'
 
 export interface Context {
   agent: Agent
+<<<<<<< HEAD
   authenticatedDid?: string
+=======
+  authenticatedDid?: Promise<string>
+>>>>>>> feat: Optionally add permissions to gql resolvers
 }
 
 export interface Order {

--- a/packages/daf-core/src/graphql/graphql-core.ts
+++ b/packages/daf-core/src/graphql/graphql-core.ts
@@ -321,6 +321,14 @@ export const resolvers = {
       args: { raw: string; metaData?: [{ type: string; value?: string }]; save: boolean },
       ctx: Context,
     ) => {
+      if (ctx.authenticatedDid) {
+        const authMeta = {type: "sender", value: ctx.authenticatedDid};
+        if (Array.isArray(args.metaData)) {
+          args.metaData.push(authMeta)
+        } else {
+          args.metaData = [authMeta]
+        }
+      }
       return ctx.agent.handleMessage(args)
     },
   },

--- a/packages/daf-core/src/graphql/graphql-core.ts
+++ b/packages/daf-core/src/graphql/graphql-core.ts
@@ -153,7 +153,7 @@ const messages = async (_: any, args: FindArgs, ctx: Context) => {
       new Brackets(qb => {
         qb.where('message.to = :ident', { ident: ctx.authenticatedDid }).orWhere('message.from = :ident', {
           ident: ctx.authenticatedDid,
-        })
+        }).orWhere('message.visibility = "public"')
       }),
     )
   }
@@ -173,7 +173,7 @@ const messagesCount = async (_: any, args: FindArgs, ctx: Context) => {
       new Brackets(qb => {
         qb.where('message.to = :ident', { ident: ctx.authenticatedDid }).orWhere('message.from = :ident', {
           ident: ctx.authenticatedDid,
-        })
+        }).orWhere('message.visibility = "public"')
       }),
     )
   }
@@ -190,11 +190,13 @@ const presentations = async (_: any, args: FindArgs, ctx: Context) => {
     .where(where)
   qb = decorateQB(qb, 'presentation', args.input)
   if (ctx.authenticatedDid) {
+    qb = qb.leftJoin("presentation.messages", "message")
     qb = qb.andWhere(
       new Brackets(qb => {
         qb.where('audience.did = :ident', {
           ident: ctx.authenticatedDid,
         }).orWhere('presentation.issuer = :ident', { ident: ctx.authenticatedDid })
+        .orWhere('message.visibility = "public"')
       }),
     )
   }
@@ -211,11 +213,13 @@ const presentationsCount = async (_: any, args: FindArgs, ctx: Context) => {
     .where(where)
   qb = decorateQB(qb, 'presentation', args.input)
   if (ctx.authenticatedDid) {
+    qb = qb.leftJoin("presentation.messages", "message")
     qb = qb.andWhere(
       new Brackets(qb => {
         qb.where('audience.did = :ident', {
           ident: ctx.authenticatedDid,
         }).orWhere('presentation.issuer = :ident', { ident: ctx.authenticatedDid })
+        .orWhere('message.visibility = "public"')
       }),
     )
   }
@@ -232,11 +236,12 @@ const credentials = async (_: any, args: FindArgs, ctx: Context) => {
     .where(where)
   qb = decorateQB(qb, 'credential', args.input)
   if (ctx.authenticatedDid) {
+    qb = qb.leftJoin("credential.messages", "message")
     qb = qb.andWhere(
       new Brackets(qb => {
         qb.where('credential.subject = :ident', { ident: ctx.authenticatedDid }).orWhere('credential.issuer = :ident', {
           ident: ctx.authenticatedDid,
-        })
+        }).orWhere('message.visibility = "public"')
       }),
     )
   }
@@ -253,11 +258,12 @@ const credentialsCount = async (_: any, args: FindArgs, ctx: Context) => {
     .where(where)
   qb = decorateQB(qb, 'credential', args.input)
   if (ctx.authenticatedDid) {
+    qb = qb.leftJoin("credential.messages", "message")
     qb = qb.andWhere(
       new Brackets(qb => {
         qb.where('credential.subject = :ident', { ident: ctx.authenticatedDid }).orWhere('credential.issuer = :ident', {
           ident: ctx.authenticatedDid,
-        })
+        }).orWhere('message.visibility = "public"')
       }),
     )
   }
@@ -341,7 +347,7 @@ export const resolvers = {
           new Brackets(qb => {
             qb.where('message.to = :ident', { ident: ctx.authenticatedDid }).orWhere('message.from = :ident', {
               ident: ctx.authenticatedDid,
-            })
+            }).orWhere('message.visibility = "public"')
           }),
         )
       }
@@ -357,11 +363,13 @@ export const resolvers = {
         .leftJoinAndSelect('presentation.audience', 'audience')
         .where('presentation.hash = :hash', { hash })
       if (ctx.authenticatedDid) {
+        qb = qb.leftJoin("presentation.messages", "message")
         qb = qb.andWhere(
           new Brackets(qb => {
             qb.where('audience.did = :ident', {
               ident: ctx.authenticatedDid,
             }).orWhere('presentation.issuer = :ident', { ident: ctx.authenticatedDid })
+            .orWhere('message.visibility = "public"')
           }),
         )
       }
@@ -377,11 +385,13 @@ export const resolvers = {
         .leftJoinAndSelect('credential.subject', 'subject')
         .where('credential.hash = :hash', { hash })
       if (ctx.authenticatedDid) {
+        qb = qb.leftJoin("credential.messages", "message")
         qb = qb.andWhere(
           new Brackets(qb => {
             qb.where('credential.subject = :ident', {
               ident: ctx.authenticatedDid,
             }).orWhere('credential.issuer = :ident', { ident: ctx.authenticatedDid })
+            .orWhere('message.visibility = "public')
           }),
         )
       }

--- a/packages/daf-core/src/index.ts
+++ b/packages/daf-core/src/index.ts
@@ -24,10 +24,10 @@ import { Identity } from './entities/identity'
 import { Claim } from './entities/claim'
 import { Credential } from './entities/credential'
 import { Presentation } from './entities/presentation'
-import { Message } from './entities/message'
+import { Message, MetaData } from './entities/message'
 
 export const Entities = [Key, Identity, Message, Claim, Credential, Presentation]
 
-export { KeyType, Key, Identity, Message, Claim, Credential, Presentation }
+export { KeyType, Key, Identity, Message, Claim, Credential, Presentation, MetaData }
 
 export { migrations } from './migrations'

--- a/packages/daf-did-jwt/src/message-handler.ts
+++ b/packages/daf-did-jwt/src/message-handler.ts
@@ -12,6 +12,7 @@ export class JwtMessageHandler extends AbstractMessageHandler {
       debug('Message.raw is a valid JWT')
       message.addMetaData({ type: decoded.header.typ, value: decoded.header.alg })
       message.data = verified.payload
+      message.visibility = verified.payload.vis
     } catch (e) {
       debug(e.message)
     }

--- a/packages/daf-selective-disclosure/src/__tests__/helper.test.ts
+++ b/packages/daf-selective-disclosure/src/__tests__/helper.test.ts
@@ -78,7 +78,7 @@ describe('daf-selective-disclosure-helper', () => {
 
     const presentation = new Presentation()
     presentation.issuer = identity
-    presentation.audience = identity
+    presentation.audience = [identity]
     presentation.context = ['https://www.w3.org/2018/credentials/v1']
     presentation.type = ['VerifiablePresentation']
     presentation.credentials = [credential1, credential3]
@@ -120,7 +120,7 @@ describe('daf-selective-disclosure-helper', () => {
 
     const presentation = new Presentation()
     presentation.issuer = identity
-    presentation.audience = identity
+    presentation.audience = [identity]
     presentation.context = ['https://www.w3.org/2018/credentials/v1']
     presentation.type = ['VerifiablePresentation']
     presentation.credentials = [credential1]

--- a/packages/daf-w3c/src/message-handler.ts
+++ b/packages/daf-w3c/src/message-handler.ts
@@ -129,8 +129,11 @@ export function createPresentation(
   vp.issuer = new Identity()
   vp.issuer.did = payload.iss
 
-  vp.audience = new Identity()
-  vp.audience.did = payload.aud
+  vp.audience = payload.aud.split(',').map((did: string) => {
+    const id = new Identity()
+    id.did = did
+    return id
+  })
 
   vp.raw = jwt
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9908,6 +9908,11 @@ sqlite3@^4.1.1:
     node-pre-gyp "^0.11.0"
     request "^2.87.0"
 
+sqlstring@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.2.tgz#cdae7169389a1375b18e885f2e60b3e460809514"
+  integrity sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg==
+
 sshpk@^1.7.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"


### PR DESCRIPTION
This is in response to our meeting from 2 weeks ago where we mentioned the need to grant access to multiple auditors or have public credentials.  There are 2 commits here. The first makes presentation and audience a many to many relationship and the second adds a visibility column to message.  These changes are incorporated into permissioning when an `authenticatedDid` is passed.  Let me know if you see a better way to support these features.