### PR TITLE
Add build step before starting the application

### DIFF
--- a/examples/rest-api/README.md
+++ b/examples/rest-api/README.md
@@ -4,6 +4,7 @@
 
 ```
 npm i
+npx lerna run build
 npm start
 ```
 


### PR DESCRIPTION
I ran into the issue that the application wouldn't start without this step. Since there's no build target in package.json this solution seems to be the easiest possible fix of the documentation.