### PR TITLE
fix: allow to pass in a custom registry address

### DIFF
--- a/packages/daf-resolver/src/resolver.ts
+++ b/packages/daf-resolver/src/resolver.ts
@@ -9,6 +9,7 @@ const debug = Debug('daf:resolver')
 interface NetworkConfig {
   name: string
   rpcUrl: string
+  registry?: string
 }
 
 interface Options {


### PR DESCRIPTION
When passing in a custom network list to the DafResolver (e.g. consortium network) it will fall back to the mainner registry address in https://github.com/decentralized-identity/ethr-did-resolver/blob/develop/src/ethr-did-resolver.js#L187

This type change allows a DAF Agent to pass in the registry address for the network in question.

I specifically did not change the networks list because it would force people that use a non infure main/testnet node to configure the address, or force you to maintain a second list of addresses from the networks.json in ethr-did-resolver package.

Do note that this networks list was removed in v2 of ethr-did-resolver so this list would need ot be adjusted anyway when upgrading.