### PR TITLE
fix: ethr resolver for private nets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ lerna-debug.log
 identity-store.json
 key-store.json
 *.sqlite
+
+.vscode/

--- a/packages/daf-ethr-did/src/identity-provider.ts
+++ b/packages/daf-ethr-did/src/identity-provider.ts
@@ -73,6 +73,7 @@ export class IdentityProvider extends AbstractIdentityProvider {
       address: toEthereumAddress(key.serialized.publicKeyHex),
       gas: this.gas,
       ttl: this.ttl,
+      registry: this.registry,
     })
 
     return new Identity({

--- a/packages/daf-resolver/package.json
+++ b/packages/daf-resolver/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "did-resolver": "^1.1.0",
-    "ethr-did-resolver": "^1.0.3",
+    "ethr-did-resolver": "2.2.0",
     "nacl-did": "^1.0.0",
     "web-did-resolver": "^1.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6717,6 +6717,19 @@ ethr-did-registry@^0.0.3:
   resolved "https://registry.yarnpkg.com/ethr-did-registry/-/ethr-did-registry-0.0.3.tgz#f363d2c73cb9572b57bd7a5c9c90c88485feceb5"
   integrity sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw==
 
+ethr-did-resolver@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ethr-did-resolver/-/ethr-did-resolver-2.2.0.tgz#bd1c838fc0140bae03e34897352da94ec514deb2"
+  integrity sha512-Ca8hucIpO0LZ0Td3vEyUGRMyStATvof7EI5knazt8xpco5ao03HA9nQJdyRL7SDu9wDvw5iC1Z/8XmbWBuKPig==
+  dependencies:
+    buffer "^5.1.0"
+    did-resolver "1.0.0"
+    ethjs-abi "^0.2.1"
+    ethjs-contract "^0.1.9"
+    ethjs-provider-http "^0.1.6"
+    ethjs-query "^0.3.5"
+    ethr-did-registry "^0.0.3"
+
 ethr-did-resolver@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ethr-did-resolver/-/ethr-did-resolver-0.2.0.tgz#1af748f1c878d45feca8d05f5d8a2eb26b4247d7"
@@ -6726,19 +6739,6 @@ ethr-did-resolver@^0.2.0:
     babel-runtime "^6.26.0"
     buffer "^5.1.0"
     did-resolver "0.0.6"
-    ethjs-abi "^0.2.1"
-    ethjs-contract "^0.1.9"
-    ethjs-provider-http "^0.1.6"
-    ethjs-query "^0.3.5"
-    ethr-did-registry "^0.0.3"
-
-ethr-did-resolver@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/ethr-did-resolver/-/ethr-did-resolver-1.0.3.tgz#8a4777c6267afe80a55a16fcee21845ddfd25104"
-  integrity sha512-9XtaB+4Ozc4W0gWHZ4J2HA+c+M7r0xcktmQI6v3GMjFto7b42Mq9zhh24kAxCqmtkqQhmUDJeqqSOIOwHrNbmQ==
-  dependencies:
-    buffer "^5.1.0"
-    did-resolver "1.0.0"
     ethjs-abi "^0.2.1"
     ethjs-contract "^0.1.9"
     ethjs-provider-http "^0.1.6"


### PR DESCRIPTION
The network configuration that is used for identity-provider did not get propagated entirely down to the identity-controller for the daf-ethr-did package; this PR fixes that.

Also, I updated the version of ethr-did-resolver being used in daf
