### PR TITLE
fix: Version takes only two parameters

### DIFF
--- a/packages/daf-cli/src/version.ts
+++ b/packages/daf-cli/src/version.ts
@@ -2,4 +2,4 @@ import program from 'commander'
 
 const { version } = require('../package.json')
 
-program.version(version, '-v, --version', 'output the current version')
+program.version(version, '-v, --version')


### PR DESCRIPTION
    /**
     * Set the program version to `str`.
     *
     * This method auto-registers the "-V, --version" flag
     * which will print the version number when passed.
     *
     * @param {string} str
     * @param {string} [flags]
     * @returns {Command} for chaining
     */
    version(str: string, flags?: string): Command;