### PR TITLE
fix: handle jwt messages correctly in daf-url in browser environments

### DIFF
--- a/packages/daf-url/src/message-handler.ts
+++ b/packages/daf-url/src/message-handler.ts
@@ -6,7 +6,7 @@ const debug = Debug('daf:url:message-handler')
 
 export class UrlMessageHandler extends AbstractMessageHandler {
   async handle(message: Message, agent: Agent): Promise<Message> {
-    const parsed = parse(message.raw, true)
+    const parsed = parse(message.raw, {}, true)
 
     if (parsed && parsed.query && parsed.query.c_i) {
       debug('Detected standard URL')


### PR DESCRIPTION
I was sending through a message with a JWT in the raw and my agent running in the browser has in the MessageHandler chain `daf-url` active. 

I ran into errors because `const parsed = parse(message.raw, true)` returned an URL object with the URL of the page. The URL came out as http://localhost:3000/jwthere. Which of course did not resolve to something daf could understand.

After some digging, I found the following in the `url-parse` documentation

> Note that when `url-parse` is used in a browser environment, it will default to
using the browser's current window location as the base URL when parsing all
inputs. To parse an input independently of the browser's current URL (e.g. for
functionality parity with the library in a Node environment), pass an empty
location object as the second parameter. (https://github.com/unshiftio/url-parse/pull/65/files)

This commit adds the {} parameter.