### PR TITLE
fix: export context from daf-selective-disclosure and daf-w3c

### DIFF
--- a/packages/daf-selective-disclosure/src/graphql.ts
+++ b/packages/daf-selective-disclosure/src/graphql.ts
@@ -3,7 +3,7 @@ import { ActionTypes, ActionSignSdr, SelectiveDisclosureRequest } from './action
 import { findCredentialsForSdr, validatePresentationAgainstSdr } from './helper'
 import { MessageTypes } from './message-handler'
 
-interface Context {
+export interface Context {
   agent: Agent
 }
 

--- a/packages/daf-w3c/src/graphql.ts
+++ b/packages/daf-w3c/src/graphql.ts
@@ -7,7 +7,7 @@ import {
   PresentationInput,
 } from './action-handler'
 
-interface Context {
+export interface Context {
   agent: Agent
 }
 


### PR DESCRIPTION
I'm sharing my daf graphql config across some repo's and i want to prepare it, and export it to be used where needed.

When doing the following:

```
export const dafResolvers = merge(
  Daf.Gql.Core.resolvers,
  Daf.Gql.IdentityManager.resolvers,
  W3cGql.resolvers
  SdrGql.resolvers
);
```

Typescript conplains that it cannot send along Context

```
Exported variable 'xxx' has or is using name 'Context' from external module "./node_modules/daf-selective-disclosure/build/graphql" but cannot be named.
```

In daf-core it is exported so i added the missing exports in both packages
