### PR TITLE
fix: return saveDate and updateDate to match the typeDefs

### DIFF
--- a/packages/daf-core/src/graphql/graphql-identity-manager.ts
+++ b/packages/daf-core/src/graphql/graphql-identity-manager.ts
@@ -14,6 +14,8 @@ const managedIdentities = async (_: any, args: any, ctx: Context) => {
   return list.map((identity: AbstractIdentity) => ({
     did: identity.did,
     provider: identity.identityProviderType,
+    saveDate: identity.saveDate,
+    updateDate: identity.updateDate,
     __typename: 'Identity',
   }))
 }


### PR DESCRIPTION
The typeDefs define that these fields are there and required

![image](https://user-images.githubusercontent.com/16780/83388784-5530e380-a3ef-11ea-82c2-2ce5026a7cdc.png)

But asking for them in the query throws an error

![image](https://user-images.githubusercontent.com/16780/83388813-6548c300-a3ef-11ea-9924-ccb1e8df33d3.png)
