### PR TITLE
Allow empty issuers in sdr credential request

### DIFF
--- a/__tests__/shared/handleSdrMessage.ts
+++ b/__tests__/shared/handleSdrMessage.ts
@@ -91,6 +91,21 @@ export default (testContext: {
       expect(verifiableCredential.proof.jwt).toBeDefined()
     })
 
+    it('should accept empty issuers array', async () => {
+      const credentials = await agent.getVerifiableCredentialsForSdr({
+        sdr: {
+          claims: [
+            {
+              claimType: 'name',
+              issuers: [],
+            },
+          ],
+        },
+      })
+
+      expect(credentials[0].credentials[0]).toHaveProperty('proof.jwt')
+    })
+
     it('should create verifiable presentation', async () => {
       const credentials = await agent.getVerifiableCredentialsForSdr({
         sdr: {

--- a/packages/daf-selective-disclosure/src/action-handler.ts
+++ b/packages/daf-selective-disclosure/src/action-handler.ts
@@ -99,7 +99,7 @@ export class SelectiveDisclosure implements IAgentPlugin {
         findArgs.where?.push({ column: 'value', value: [credentialRequest.claimValue] })
       }
 
-      if (credentialRequest.issuers) {
+      if (credentialRequest.issuers && credentialRequest.issuers.length > 0) {
         findArgs.where?.push({ column: 'issuer', value: credentialRequest.issuers.map((i) => i.did) })
       }
 


### PR DESCRIPTION
fixes error: `{"error":"syntax error at or near \")\""}`

This prevents from checking the db if `issuers` is empty. (The message sdr payload has an empty issuers array if no issuers are provided)