### PR TITLE
fix: Disable schemaValidation in CLI default config

### DIFF
--- a/packages/daf-cli/default/default.yml
+++ b/packages/daf-cli/default/default.yml
@@ -46,7 +46,7 @@ messageHandler:
 agent:
   $require: daf-core#Agent
   $args:
-    - schemaValidation: true
+    - schemaValidation: false
       plugins:
         - $require: daf-key-manager#KeyManager
           $args:


### PR DESCRIPTION
Calling `daf create-config` will generate an `agent.yml` file with `schemaValidation` set to `false`.
This makes it a bit easier to work through issues with inconsistent responses from some plugins.
This will also match the default for the `agent`.