### PR TITLE
Web DID path (multi user) support 

### DIFF
--- a/__tests__/restAgent.test.ts
+++ b/__tests__/restAgent.test.ts
@@ -145,7 +145,6 @@ const setup = async (options?: IAgentOptions): Promise<boolean> => {
   const agentRouter = AgentRouter({
     getAgentForRequest: async (req) => serverAgent,
     exposedMethods: serverAgent.availableMethods(),
-    basePath,
   })
 
   return new Promise((resolve) => {

--- a/packages/daf-cli/src/server.ts
+++ b/packages/daf-cli/src/server.ts
@@ -2,7 +2,7 @@ import express from 'express'
 import program from 'commander'
 import ngrok from 'ngrok'
 import parse from 'url-parse'
-import { AgentRouter, ApiSchemaRouter, DidDocRouter, didDocEndpoint } from 'daf-express'
+import { AgentRouter, ApiSchemaRouter, WebDidDocRouter, didDocEndpoint } from 'daf-express'
 import swaggerUi from 'swagger-ui-express'
 import { getAgent, getConfig } from './setup'
 import { createObjects } from './lib/objectCreator'
@@ -99,9 +99,10 @@ program
 
     /**
      * Handling 'did:web' requests ('/.well-known/did.json' and '/^\/(.+)\/did.json$/')
+     * warning: 'did:web' method requires HTTPS (that is one of the reasons to use ngrok for development)
      */
     console.log('📋 DID Document ' + baseUrl + didDocEndpoint)
-    app.use(DidDocRouter({ getAgentForRequest }))
+    app.use(WebDidDocRouter({ getAgentForRequest }))
 
     console.log('📖 API Documentation', baseUrl + options.apiDocsPath)
     app.use(
@@ -164,6 +165,14 @@ program
         { label: 'DID Document', url: didDocEndpoint },
       ]
 
+      /**
+       * This is experimental feature. You can create a verifiable presentation containing 
+       * public profile verifiable credentials. 
+       * 
+       * `verifier` of this VP should be set as 
+       * url of your home page, ex: https://bob-did.eu.ngrok.io
+       * 
+       */
       let verifiablePresentation
       if (serverIdentity) {
         const presentations = await agent.dataStoreORMGetVerifiablePresentations({

--- a/packages/daf-cli/src/server.ts
+++ b/packages/daf-cli/src/server.ts
@@ -2,12 +2,13 @@ import express from 'express'
 import program from 'commander'
 import ngrok from 'ngrok'
 import parse from 'url-parse'
-import { AgentRouter, AgentApiSchemaRouter, AgentDidDocRouter, didDocEndpoint } from 'daf-express'
+import { AgentRouter, ApiSchemaRouter, DidDocRouter, didDocEndpoint } from 'daf-express'
 import swaggerUi from 'swagger-ui-express'
 import { getAgent, getConfig } from './setup'
 import { createObjects } from './lib/objectCreator'
 import passport from 'passport'
 import Bearer from 'passport-http-bearer'
+import { IIdentity } from 'daf-core'
 const exphbs = require('express-handlebars')
 const hbs = exphbs.create({
   helpers: {
@@ -26,13 +27,30 @@ program
     const agent = getAgent(program.config)
     const { server: options } = createObjects(getConfig(program.config), { server: '/server' })
 
-    const exposedMethods = options.exposedMethods ? options.exposedMethods : agent.availableMethods()
+    /**
+     * Ngrok configuration
+     */
+    let baseUrl = options.baseUrl
+    if (options.ngrok?.connect) {
+      baseUrl = await ngrok.connect({
+        addr: cmd.port || options.port,
+        subdomain: options.ngrok.subdomain,
+        region: options.ngrok.region,
+        authtoken: options.ngrok.authtoken,
+      })
+      app.set('trust proxy', 'loopback')
+    }
+    const hostname = parse(baseUrl).hostname
 
+    /**
+     *  Authentication setup
+     */
     let authMiddleware = (req: any, res: any, next: any) => {
       next()
     }
     let securityScheme
     if (options.apiKey) {
+      console.log('🔐 Secured by API Key')
       passport.use(
         new Bearer.Strategy((token, done) => {
           if (!options.apiKey || options.apiKey === token) {
@@ -47,8 +65,13 @@ program
       securityScheme = 'bearer'
     }
 
+    /**
+     * Exposing agent methods
+     */
+    const exposedMethods = options.exposedMethods ? options.exposedMethods : agent.availableMethods()
     const getAgentForRequest = async (req: express.Request) => agent
 
+    console.log('🗺  API base path', baseUrl + options.apiBasePath)
     app.use(
       options.apiBasePath,
       authMiddleware,
@@ -58,9 +81,15 @@ program
       }),
     )
 
+    /**
+     * Exposing OpenAPI schema
+     */
+    console.log('🗺  OpenAPI schema', baseUrl + options.schemaPath)
+    console.log('🧩 Available methods', agent.availableMethods().length)
+    console.log('🛠  Exposed methods', exposedMethods.length)
     app.use(
       options.schemaPath,
-      AgentApiSchemaRouter({
+      ApiSchemaRouter({
         basePath: options.apiBasePath,
         getAgentForRequest,
         exposedMethods,
@@ -68,95 +97,92 @@ program
       }),
     )
 
-    app.use(AgentDidDocRouter({ getAgentForRequest }))
+    /**
+     * Handling 'did:web' requests ('/.well-known/did.json' and '/^\/(.+)\/did.json$/')
+     */
+    console.log('📋 DID Document ' + baseUrl + didDocEndpoint)
+    app.use(DidDocRouter({ getAgentForRequest }))
+
+    console.log('📖 API Documentation', baseUrl + options.apiDocsPath)
+    app.use(
+      options.apiDocsPath,
+      swaggerUi.serve,
+      swaggerUi.setup(undefined, {
+        swaggerOptions: {
+          url: baseUrl + options.schemaPath,
+        },
+      }),
+    )
+
+    /**
+     * Creating server identity and configuring messaging service endpoint
+     */
+    let serverIdentity: IIdentity
+    if (options.defaultIdentity.create) {
+      serverIdentity = await agent.identityManagerGetOrCreateIdentity({
+        provider: 'did:web',
+        alias: hostname,
+      })
+      console.log('🆔', serverIdentity.did)
+
+      const messagingServiceEndpoint = baseUrl + options.defaultIdentity.messagingServiceEndpoint
+
+      console.log('📨 Messaging endpoint', messagingServiceEndpoint)
+      await agent.identityManagerAddService({
+        did: serverIdentity.did,
+        service: {
+          id: serverIdentity.did + '#msg',
+          type: 'Messaging',
+          description: 'Handles incoming POST messages',
+          serviceEndpoint: messagingServiceEndpoint,
+        },
+      })
+
+      app.post(
+        options.defaultIdentity.messagingServiceEndpoint,
+        express.text({ type: '*/*' }),
+        async (req, res) => {
+          try {
+            const message = await agent.handleMessage({ raw: req.body, save: true })
+            console.log('Received message', message.type, message.id)
+            res.json({ id: message.id })
+          } catch (e) {
+            console.log(e)
+            res.send(e.message)
+          }
+        },
+      )
+    }
+
+    /**
+     * Serving homepage
+     */
+    app.get('/', async (req, res) => {
+      const links = [
+        { label: 'API Docs', url: options.apiDocsPath },
+        { label: 'API Schema', url: options.schemaPath },
+        { label: 'DID Document', url: didDocEndpoint },
+      ]
+
+      let verifiablePresentation
+      if (serverIdentity) {
+        const presentations = await agent.dataStoreORMGetVerifiablePresentations({
+          where: [
+            { column: 'holder', value: [serverIdentity.did] },
+            { column: 'verifier', value: [baseUrl] },
+          ],
+        })
+
+        verifiablePresentation =
+          presentations.length > 0 ? presentations[presentations.length - 1].verifiablePresentation : null
+      }
+
+      const template = options.homePageTemplate || __dirname + '/../views/home.html'
+      const rendered = await hbs.render(template, { verifiablePresentation, links })
+      res.send(rendered)
+    })
 
     app.listen(cmd.port || options.port, async () => {
-      console.log(`🚀 Agent server ready at http://localhost:${cmd.port || options.port}`)
-      console.log('🧩 Available methods', agent.availableMethods().length)
-      console.log('🛠  Exposed methods', exposedMethods.length)
-
-      let baseUrl = options.baseUrl
-
-      if (options.ngrok?.connect) {
-        baseUrl = await ngrok.connect({
-          addr: cmd.port || options.port,
-          subdomain: options.ngrok.subdomain,
-          region: options.ngrok.region,
-          authtoken: options.ngrok.authtoken,
-        })
-        app.set('trust proxy', 'loopback')
-      }
-      const hostname = parse(baseUrl).hostname
-
-      app.use(
-        options.apiDocsPath,
-        swaggerUi.serve,
-        swaggerUi.setup(undefined, {
-          swaggerOptions: {
-            url: baseUrl + options.schemaPath,
-          },
-        }),
-      )
-      console.log('📖 API Documentation', baseUrl + options.apiDocsPath)
-      console.log('🗺  OpenAPI schema', baseUrl + options.schemaPath)
-
-      if (options.defaultIdentity.create) {
-        let serverIdentity = await agent.identityManagerGetOrCreateIdentity({
-          provider: 'did:web',
-          alias: hostname,
-        })
-        console.log('🆔', serverIdentity.did)
-
-        const messagingServiceEndpoint = baseUrl + options.defaultIdentity.messagingServiceEndpoint
-
-        await agent.identityManagerAddService({
-          did: serverIdentity.did,
-          service: {
-            id: serverIdentity.did + '#msg',
-            type: 'Messaging',
-            description: 'Handles incoming POST messages',
-            serviceEndpoint: messagingServiceEndpoint,
-          },
-        })
-        console.log('📨 Messaging endpoint', messagingServiceEndpoint)
-
-        app.post(
-          options.defaultIdentity.messagingServiceEndpoint,
-          express.text({ type: '*/*' }),
-          async (req, res) => {
-            try {
-              const message = await agent.handleMessage({ raw: req.body, save: true })
-              console.log('Received message', message.type, message.id)
-              res.json({ id: message.id })
-            } catch (e) {
-              console.log(e)
-              res.send(e.message)
-            }
-          },
-        )
-
-        console.log('📋 DID Document ' + baseUrl + didDocEndpoint)
-
-        app.get('/', async (req, res) => {
-          const links = [
-            { label: 'API Docs', url: options.apiDocsPath },
-            { label: 'API Schema', url: options.schemaPath },
-            { label: 'DID Document', url: didDocEndpoint },
-          ]
-
-          const presentations = await agent.dataStoreORMGetVerifiablePresentations({
-            where: [
-              { column: 'holder', value: [serverIdentity.did] },
-              { column: 'verifier', value: [baseUrl] },
-            ],
-          })
-
-          const verifiablePresentation =
-            presentations.length > 0 ? presentations[presentations.length - 1].verifiablePresentation : null
-          const template = options.homePageTemplate || __dirname + '/../views/home.html'
-          const rendered = await hbs.render(template, { verifiablePresentation, links })
-          res.send(rendered)
-        })
-      }
+      console.log(`🚀 Cloud Agent ready at ${baseUrl}`)
     })
   })

--- a/packages/daf-cli/views/home.html
+++ b/packages/daf-cli/views/home.html
@@ -1,5 +1,3 @@
-{{#with verifiablePresentation}} {{#each verifiableCredential}} {{toJSON credentialSubject}}
-<hr />
-{{/each}} {{/with}} {{#each links}}
+{{#each links}}
 <a href="{{url}}">{{label}}</a><br />
 {{/each}}

--- a/packages/daf-express/api/daf-express.api.md
+++ b/packages/daf-express/api/daf-express.api.md
@@ -5,18 +5,40 @@
 ```ts
 
 import { IAgent } from 'daf-core';
+import { IIdentityManager } from 'daf-core';
 import { Request as Request_2 } from 'express';
 import { Router } from 'express';
+import { TAgent } from 'daf-core';
 
 // @public
 export const AgentRouter: (options: AgentRouterOptions) => Router;
 
 // @public (undocumented)
 export interface AgentRouterOptions {
+    exposedMethods: Array<string>;
+    getAgentForRequest: (req: Request_2) => Promise<IAgent>;
+}
+
+// @public
+export const ApiSchemaRouter: (options: ApiSchemaRouterOptions) => Router;
+
+// @public (undocumented)
+export interface ApiSchemaRouterOptions {
     basePath: string;
     exposedMethods: Array<string>;
     getAgentForRequest: (req: Request_2) => Promise<IAgent>;
-    serveSchema?: boolean;
+    securityScheme?: string;
+}
+
+// @public (undocumented)
+export const didDocEndpoint = "/.well-known/did.json";
+
+// @public
+export const DidDocRouter: (options: DidDocRouterOptions) => Router;
+
+// @public (undocumented)
+export interface DidDocRouterOptions {
+    getAgentForRequest: (req: Request_2) => Promise<TAgent<IIdentityManager>>;
 }
 
 

--- a/packages/daf-express/api/daf-express.api.md
+++ b/packages/daf-express/api/daf-express.api.md
@@ -34,10 +34,10 @@ export interface ApiSchemaRouterOptions {
 export const didDocEndpoint = "/.well-known/did.json";
 
 // @public
-export const DidDocRouter: (options: DidDocRouterOptions) => Router;
+export const WebDidDocRouter: (options: WebDidDocRouterOptions) => Router;
 
 // @public (undocumented)
-export interface DidDocRouterOptions {
+export interface WebDidDocRouterOptions {
     getAgentForRequest: (req: Request_2) => Promise<TAgent<IIdentityManager>>;
 }
 

--- a/packages/daf-express/src/agent-router.ts
+++ b/packages/daf-express/src/agent-router.ts
@@ -1,6 +1,5 @@
-import { IAgent, IIdentity, IIdentityManager, TAgent } from 'daf-core'
+import { IAgent } from 'daf-core'
 import { Request, Response, NextFunction, Router, json } from 'express'
-import { getOpenApiSchema } from 'daf-rest'
 import Debug from 'debug'
 
 interface RequestWithAgent extends Request {

--- a/packages/daf-express/src/agent-router.ts
+++ b/packages/daf-express/src/agent-router.ts
@@ -1,0 +1,65 @@
+import { IAgent, IIdentity, IIdentityManager, TAgent } from 'daf-core'
+import { Request, Response, NextFunction, Router, json } from 'express'
+import { getOpenApiSchema } from 'daf-rest'
+import Debug from 'debug'
+
+interface RequestWithAgent extends Request {
+  agent?: IAgent
+}
+
+/**
+ * @public
+ */
+export interface AgentRouterOptions {
+  /**
+   * Function that returns configured agent for specific request
+   */
+  getAgentForRequest: (req: Request) => Promise<IAgent>
+
+  /**
+   * List of exposed methods
+   */
+  exposedMethods: Array<string>
+}
+
+/**
+ * Creates a router that exposes {@link daf-core#Agent} methods
+ *
+ * @param options - Initialization option
+ * @returns Expressjs router
+ */
+export const AgentRouter = (options: AgentRouterOptions): Router => {
+  const router = Router()
+  router.use(json())
+  router.use(async (req: RequestWithAgent, res, next) => {
+    req.agent = await options.getAgentForRequest(req)
+    next()
+  })
+
+  for (const exposedMethod of options.exposedMethods) {
+    Debug('daf:express:initializing')(exposedMethod)
+
+    router.post('/' + exposedMethod, async (req: RequestWithAgent, res: Response, next: NextFunction) => {
+      if (!req.agent) throw Error('Agent not available')
+      try {
+        const result = await req.agent.execute(exposedMethod, req.body)
+        res.status(200).json(result)
+      } catch (e) {
+        if (e.name === 'ValidationError') {
+          res.status(400).json({
+            name: 'ValidationError',
+            message: e.message,
+            method: e.method,
+            path: e.path,
+            code: e.code,
+            description: e.description,
+          })
+        } else {
+          res.status(500).json({ error: e.message })
+        }
+      }
+    })
+  }
+
+  return router
+}

--- a/packages/daf-express/src/api-schema-router.ts
+++ b/packages/daf-express/src/api-schema-router.ts
@@ -1,0 +1,76 @@
+import { IAgent, IIdentity, IIdentityManager, TAgent } from 'daf-core'
+import { Request, Response, NextFunction, Router, json } from 'express'
+import { getOpenApiSchema } from 'daf-rest'
+import Debug from 'debug'
+
+interface RequestWithAgentIdentityManager extends Request {
+  agent?: TAgent<IIdentityManager>
+}
+
+interface RequestWithAgent extends Request {
+  agent?: IAgent
+}
+
+/**
+ * @public
+ */
+export interface ApiSchemaRouterOptions {
+  /**
+   * Function that returns configured agent for specific request
+   */
+  getAgentForRequest: (req: Request) => Promise<IAgent>
+
+  /**
+   * List of exposed methods
+   */
+  exposedMethods: Array<string>
+
+  /**
+   * Base path
+   */
+  basePath: string
+
+  /**
+   * Security scheme
+   * @example
+   * ```
+   * 'bearer'
+   * ```
+   */
+  securityScheme?: string
+}
+
+/**
+ * Creates a router that exposes {@link daf-core#Agent} OpenAPI schema
+ *
+ * @param options - Initialization option
+ * @returns Expressjs router
+ */
+export const ApiSchemaRouter = (options: ApiSchemaRouterOptions): Router => {
+  const router = Router()
+  router.use(async (req: RequestWithAgent, res, next) => {
+    req.agent = await options.getAgentForRequest(req)
+    next()
+  })
+
+  router.get('/', (req: RequestWithAgent, res) => {
+    if (req.agent) {
+      const openApiSchema = getOpenApiSchema(req.agent, '', options.exposedMethods)
+      const url = req.protocol + '://' + req.hostname + options.basePath
+      openApiSchema.servers = [{ url }]
+
+      if (options.securityScheme && openApiSchema.components) {
+        openApiSchema.components.securitySchemes = {
+          auth: { type: 'http', scheme: options.securityScheme },
+        }
+        openApiSchema.security = [{ auth: [] }]
+      }
+
+      res.json(openApiSchema)
+    } else {
+      res.status(500).json({ error: 'Agent not available' })
+    }
+  })
+
+  return router
+}

--- a/packages/daf-express/src/api-schema-router.ts
+++ b/packages/daf-express/src/api-schema-router.ts
@@ -1,11 +1,6 @@
-import { IAgent, IIdentity, IIdentityManager, TAgent } from 'daf-core'
-import { Request, Response, NextFunction, Router, json } from 'express'
+import { IAgent } from 'daf-core'
+import { Request, Router } from 'express'
 import { getOpenApiSchema } from 'daf-rest'
-import Debug from 'debug'
-
-interface RequestWithAgentIdentityManager extends Request {
-  agent?: TAgent<IIdentityManager>
-}
 
 interface RequestWithAgent extends Request {
   agent?: IAgent

--- a/packages/daf-express/src/did-doc-router.ts
+++ b/packages/daf-express/src/did-doc-router.ts
@@ -1,0 +1,89 @@
+import { IAgent, IIdentity, IIdentityManager, TAgent } from 'daf-core'
+import { Request, Response, NextFunction, Router, json } from 'express'
+import { getOpenApiSchema } from 'daf-rest'
+import Debug from 'debug'
+
+interface RequestWithAgentIdentityManager extends Request {
+  agent?: TAgent<IIdentityManager>
+}
+
+interface RequestWithAgent extends Request {
+  agent?: IAgent
+}
+
+export const didDocEndpoint = '/.well-known/did.json'
+/**
+ * @public
+ */
+export interface DidDocRouterOptions {
+  /**
+   * Function that returns configured agent for specific request
+   */
+  getAgentForRequest: (req: Request) => Promise<TAgent<IIdentityManager>>
+}
+/**
+ * Creates a router that serves `did:web` DID Documents
+ *
+ * @param options - Initialization option
+ * @returns Expressjs router
+ */
+export const DidDocRouter = (options: DidDocRouterOptions): Router => {
+  const router = Router()
+  router.use(async (req: RequestWithAgent, res, next) => {
+    req.agent = await options.getAgentForRequest(req)
+    next()
+  })
+
+  const didDocForIdentity = (identity: IIdentity) => {
+    const didDoc = {
+      '@context': 'https://w3id.org/did/v1',
+      id: identity.did,
+      publicKey: identity.keys.map((key) => ({
+        id: identity.did + '#' + key.kid,
+        type: key.type === 'Secp256k1' ? 'Secp256k1VerificationKey2018' : 'Ed25519VerificationKey2018',
+        controller: identity.did,
+        publicKeyHex: key.publicKeyHex,
+      })),
+      authentication: identity.keys.map((key) => ({
+        type:
+          key.type === 'Secp256k1'
+            ? 'Secp256k1SignatureAuthentication2018'
+            : 'Ed25519SignatureAuthentication2018',
+        publicKey: identity.did + '#' + key.kid,
+      })),
+      service: identity.services,
+    }
+
+    return didDoc
+  }
+
+  router.get(didDocEndpoint, async (req: RequestWithAgentIdentityManager, res) => {
+    if (req.agent) {
+      try {
+        const serverIdentity = await req.agent.identityManagerGetIdentity({
+          did: 'did:web:' + req.hostname,
+        })
+        const didDoc = didDocForIdentity(serverIdentity)
+        res.json(didDoc)
+      } catch (e) {
+        res.status(404).send(e)
+      }
+    }
+  })
+
+  router.get(/^\/(.+)\/did.json$/, async (req: RequestWithAgentIdentityManager, res) => {
+    if (req.agent) {
+      try {
+        const identity = await req.agent.identityManagerGetIdentity({
+          did: 'did:web:' + req.hostname + ':' + req.params[0].replace('/', ':'),
+        })
+        const didDoc = didDocForIdentity(identity)
+        res.json(didDoc)
+      } catch (e) {
+        res.status(404).send(e)
+      }
+    }
+  })
+
+  return router
+}

--- a/packages/daf-express/src/index.ts
+++ b/packages/daf-express/src/index.ts
@@ -5,228 +5,38 @@
  * ```typescript
  * import express from 'express'
  * import { agent } from './agent'
- * import { AgentRouter } from 'daf-express'
+ * import { AgentRouter, ApiSchemaRouter, DidDocRouter } from 'daf-express'
+ *
+ * const getAgentForRequest = async (req: express.Request) => agent
+ * const exposedMethods = agent.availableMethods()
+ * const basePath = '/agent'
+ * const schemaPath = '/open-api.json'
  *
  * const agentRouter = AgentRouter({
- *   getAgentForRequest: async req => agent,
- *   exposedMethods: agent.availableMethods()
+ *   getAgentForRequest,
+ *   exposedMethods,
+ * })
+ *
+ * const schemaRouter = ApiSchemaRouter({
+ *  basePath,
+ *  getAgentForRequest,
+ *  exposedMethods,
+ * })
+ *
+ * const didDocRouter = DidDocRouter({
+ *   getAgentForRequest
  * })
  *
  * const app = express()
- * app.use('/agent', agentRouter)
+ * app.use(basePath, agentRouter)
+ * app.use(schemaPath, schemaRouter)
+ * app.use(didDocRouter)
  * app.listen(3002)
  * ```
  *
  * @packageDocumentation
  */
 
-import { IAgent, IIdentity, IIdentityManager, TAgent } from 'daf-core'
-import { Request, Response, NextFunction, Router, json } from 'express'
-import { getOpenApiSchema } from 'daf-rest'
-import Debug from 'debug'
-
-interface RequestWithAgent extends Request {
-  agent?: IAgent
-}
-
-/**
- * @public
- */
-export interface AgentRouterOptions {
-  /**
-   * Function that returns configured agent for specific request
-   */
-  getAgentForRequest: (req: Request) => Promise<IAgent>
-
-  /**
-   * List of exposed methods
-   */
-  exposedMethods: Array<string>
-}
-
-/**
- * Creates a router that exposes {@link daf-core#Agent} methods
- *
- * @param options - Initialization option
- * @returns Expressjs router
- */
-export const AgentRouter = (options: AgentRouterOptions): Router => {
-  const router = Router()
-  router.use(json())
-  router.use(async (req: RequestWithAgent, res, next) => {
-    req.agent = await options.getAgentForRequest(req)
-    next()
-  })
-
-  for (const exposedMethod of options.exposedMethods) {
-    Debug('daf:express:initializing')(exposedMethod)
-
-    router.post('/' + exposedMethod, async (req: RequestWithAgent, res: Response, next: NextFunction) => {
-      if (!req.agent) throw Error('Agent not available')
-      try {
-        const result = await req.agent.execute(exposedMethod, req.body)
-        res.status(200).json(result)
-      } catch (e) {
-        if (e.name === 'ValidationError') {
-          res.status(400).json({
-            name: 'ValidationError',
-            message: e.message,
-            method: e.method,
-            path: e.path,
-            code: e.code,
-            description: e.description,
-          })
-        } else {
-          res.status(500).json({ error: e.message })
-        }
-      }
-    })
-  }
-
-  return router
-}
-
-/**
- * @public
- */
-export interface AgentApiSchemaRouterOptions {
-  /**
-   * Function that returns configured agent for specific request
-   */
-  getAgentForRequest: (req: Request) => Promise<IAgent>
-
-  /**
-   * List of exposed methods
-   */
-  exposedMethods: Array<string>
-
-  /**
-   * Base path
-   */
-  basePath: string
-
-  /**
-   * Security scheme
-   * @example
-   * ```
-   * 'bearer'
-   * ```
-   */
-  securityScheme?: string
-}
-
-/**
- * Creates a router that exposes {@link daf-core#Agent} OpenAPI schema
- *
- * @param options - Initialization option
- * @returns Expressjs router
- */
-export const AgentApiSchemaRouter = (options: AgentApiSchemaRouterOptions): Router => {
-  const router = Router()
-  router.use(async (req: RequestWithAgent, res, next) => {
-    req.agent = await options.getAgentForRequest(req)
-    next()
-  })
-
-  router.get('/', (req: RequestWithAgent, res) => {
-    if (req.agent) {
-      const openApiSchema = getOpenApiSchema(req.agent, '', options.exposedMethods)
-      const url = req.protocol + '://' + req.hostname + options.basePath
-      openApiSchema.servers = [{ url }]
-
-      if (options.securityScheme && openApiSchema.components) {
-        openApiSchema.components.securitySchemes = {
-          auth: { type: 'http', scheme: options.securityScheme },
-        }
-        openApiSchema.security = [{ auth: [] }]
-      }
-
-      res.json(openApiSchema)
-    } else {
-      res.status(500).json({ error: 'Agent not available' })
-    }
-  })
-
-  return router
-}
-
-interface RequestWithAgentIdentityManager extends Request {
-  agent?: TAgent<IIdentityManager>
-}
-
-export const didDocEndpoint = '/.well-known/did.json'
-/**
- * @public
- */
-export interface AgentDidDocRouterOptions {
-  /**
-   * Function that returns configured agent for specific request
-   */
-  getAgentForRequest: (req: Request) => Promise<TAgent<IIdentityManager>>
-}
-/**
- * Creates a router that serves `did:web` DID Documents
- *
- * @param options - Initialization option
- * @returns Expressjs router
- */
-export const AgentDidDocRouter = (options: AgentDidDocRouterOptions): Router => {
-  const router = Router()
-  router.use(async (req: RequestWithAgent, res, next) => {
-    req.agent = await options.getAgentForRequest(req)
-    next()
-  })
-
-  const didDocForIdentity = (identity: IIdentity) => {
-    const didDoc = {
-      '@context': 'https://w3id.org/did/v1',
-      id: identity.did,
-      publicKey: identity.keys.map((key) => ({
-        id: identity.did + '#' + key.kid,
-        type: key.type === 'Secp256k1' ? 'Secp256k1VerificationKey2018' : 'Ed25519VerificationKey2018',
-        controller: identity.did,
-        publicKeyHex: key.publicKeyHex,
-      })),
-      authentication: identity.keys.map((key) => ({
-        type:
-          key.type === 'Secp256k1'
-            ? 'Secp256k1SignatureAuthentication2018'
-            : 'Ed25519SignatureAuthentication2018',
-        publicKey: identity.did + '#' + key.kid,
-      })),
-      service: identity.services,
-    }
-
-    return didDoc
-  }
-
-  router.get(didDocEndpoint, async (req: RequestWithAgentIdentityManager, res) => {
-    if (req.agent) {
-      try {
-        const serverIdentity = await req.agent.identityManagerGetIdentity({
-          did: 'did:web:' + req.hostname,
-        })
-        const didDoc = didDocForIdentity(serverIdentity)
-        res.json(didDoc)
-      } catch (e) {
-        res.status(404).send(e)
-      }
-    }
-  })
-
-  router.get(/^\/(.+)\/did.json$/, async (req: RequestWithAgentIdentityManager, res) => {
-    if (req.agent) {
-      try {
-        const identity = await req.agent.identityManagerGetIdentity({
-          did: 'did:web:' + req.hostname + ':' + req.params[0].replace('/', ':'),
-        })
-        const didDoc = didDocForIdentity(identity)
-        res.json(didDoc)
-      } catch (e) {
-        res.status(404).send(e)
-      }
-    }
-  })
-
-  return router
-}
+export { AgentRouter, AgentRouterOptions } from './agent-router'
+export { ApiSchemaRouter, ApiSchemaRouterOptions } from './api-schema-router'
+export { DidDocRouter, DidDocRouterOptions, didDocEndpoint } from './did-doc-router'

--- a/packages/daf-express/src/index.ts
+++ b/packages/daf-express/src/index.ts
@@ -5,7 +5,7 @@
  * ```typescript
  * import express from 'express'
  * import { agent } from './agent'
- * import { AgentRouter, ApiSchemaRouter, DidDocRouter } from 'daf-express'
+ * import { AgentRouter, ApiSchemaRouter, WebDidDocRouter } from 'daf-express'
  *
  * const getAgentForRequest = async (req: express.Request) => agent
  * const exposedMethods = agent.availableMethods()
@@ -23,7 +23,7 @@
  *  exposedMethods,
  * })
  *
- * const didDocRouter = DidDocRouter({
+ * const didDocRouter = WebDidDocRouter({
  *   getAgentForRequest
  * })
  *
@@ -39,4 +39,4 @@
 
 export { AgentRouter, AgentRouterOptions } from './agent-router'
 export { ApiSchemaRouter, ApiSchemaRouterOptions } from './api-schema-router'
-export { DidDocRouter, DidDocRouterOptions, didDocEndpoint } from './did-doc-router'
+export { WebDidDocRouter, WebDidDocRouterOptions, didDocEndpoint } from './web-did-doc-router'

--- a/packages/daf-express/src/index.ts
+++ b/packages/daf-express/src/index.ts
@@ -20,7 +20,7 @@
  * @packageDocumentation
  */
 
-import { IAgent } from 'daf-core'
+import { IAgent, IIdentity, IIdentityManager, TAgent } from 'daf-core'
 import { Request, Response, NextFunction, Router, json } from 'express'
 import { getOpenApiSchema } from 'daf-rest'
 import Debug from 'debug'
@@ -42,16 +42,6 @@ export interface AgentRouterOptions {
    * List of exposed methods
    */
   exposedMethods: Array<string>
-
-  /**
-   * Base path
-   */
-  basePath: string
-
-  /**
-   * If set to `true`, router will serve OpenAPI schema JSON on `/` route
-   */
-  serveSchema?: boolean
 }
 
 /**
@@ -68,7 +58,6 @@ export const AgentRouter = (options: AgentRouterOptions): Router => {
     next()
   })
 
-
   for (const exposedMethod of options.exposedMethods) {
     Debug('daf:express:initializing')(exposedMethod)
 
@@ -79,13 +68,13 @@ export const AgentRouter = (options: AgentRouterOptions): Router => {
         res.status(200).json(result)
       } catch (e) {
         if (e.name === 'ValidationError') {
-          res.status(400).json({ 
+          res.status(400).json({
             name: 'ValidationError',
             message: e.message,
             method: e.method,
             path: e.path,
             code: e.code,
-            description: e.description
+            description: e.description,
           })
         } else {
           res.status(500).json({ error: e.message })
@@ -94,16 +83,150 @@ export const AgentRouter = (options: AgentRouterOptions): Router => {
     })
   }
 
-  if (options.serveSchema) {
-    router.get('/', (req: RequestWithAgent, res) => {
-      if (req.agent) {
-        const openApi = getOpenApiSchema(req.agent, options.basePath, options.exposedMethods)
-        res.json(openApi)
-      } else {
-        res.status(500).json({ error: 'Agent not available'})
+  return router
+}
+
+/**
+ * @public
+ */
+export interface AgentApiSchemaRouterOptions {
+  /**
+   * Function that returns configured agent for specific request
+   */
+  getAgentForRequest: (req: Request) => Promise<IAgent>
+
+  /**
+   * List of exposed methods
+   */
+  exposedMethods: Array<string>
+
+  /**
+   * Base path
+   */
+  basePath: string
+
+  /**
+   * Security scheme
+   * @example
+   * ```
+   * 'bearer'
+   * ```
+   */
+  securityScheme?: string
+}
+
+/**
+ * Creates a router that exposes {@link daf-core#Agent} OpenAPI schema
+ *
+ * @param options - Initialization option
+ * @returns Expressjs router
+ */
+export const AgentApiSchemaRouter = (options: AgentApiSchemaRouterOptions): Router => {
+  const router = Router()
+  router.use(async (req: RequestWithAgent, res, next) => {
+    req.agent = await options.getAgentForRequest(req)
+    next()
+  })
+
+  router.get('/', (req: RequestWithAgent, res) => {
+    if (req.agent) {
+      const openApiSchema = getOpenApiSchema(req.agent, '', options.exposedMethods)
+      const url = req.protocol + '://' + req.hostname + options.basePath
+      openApiSchema.servers = [{ url }]
+
+      if (options.securityScheme && openApiSchema.components) {
+        openApiSchema.components.securitySchemes = {
+          auth: { type: 'http', scheme: options.securityScheme },
+        }
+        openApiSchema.security = [{ auth: [] }]
       }
-    })
+
+      res.json(openApiSchema)
+    } else {
+      res.status(500).json({ error: 'Agent not available' })
+    }
+  })
+
+  return router
+}
+
+interface RequestWithAgentIdentityManager extends Request {
+  agent?: TAgent<IIdentityManager>
+}
+
+export const didDocEndpoint = '/.well-known/did.json'
+/**
+ * @public
+ */
+export interface AgentDidDocRouterOptions {
+  /**
+   * Function that returns configured agent for specific request
+   */
+  getAgentForRequest: (req: Request) => Promise<TAgent<IIdentityManager>>
+}
+/**
+ * Creates a router that serves `did:web` DID Documents
+ *
+ * @param options - Initialization option
+ * @returns Expressjs router
+ */
+export const AgentDidDocRouter = (options: AgentDidDocRouterOptions): Router => {
+  const router = Router()
+  router.use(async (req: RequestWithAgent, res, next) => {
+    req.agent = await options.getAgentForRequest(req)
+    next()
+  })
+
+  const didDocForIdentity = (identity: IIdentity) => {
+    const didDoc = {
+      '@context': 'https://w3id.org/did/v1',
+      id: identity.did,
+      publicKey: identity.keys.map((key) => ({
+        id: identity.did + '#' + key.kid,
+        type: key.type === 'Secp256k1' ? 'Secp256k1VerificationKey2018' : 'Ed25519VerificationKey2018',
+        controller: identity.did,
+        publicKeyHex: key.publicKeyHex,
+      })),
+      authentication: identity.keys.map((key) => ({
+        type:
+          key.type === 'Secp256k1'
+            ? 'Secp256k1SignatureAuthentication2018'
+            : 'Ed25519SignatureAuthentication2018',
+        publicKey: identity.did + '#' + key.kid,
+      })),
+      service: identity.services,
+    }
+
+    return didDoc
   }
+
+  router.get(didDocEndpoint, async (req: RequestWithAgentIdentityManager, res) => {
+    if (req.agent) {
+      try {
+        const serverIdentity = await req.agent.identityManagerGetIdentity({
+          did: 'did:web:' + req.hostname,
+        })
+        const didDoc = didDocForIdentity(serverIdentity)
+        res.json(didDoc)
+      } catch (e) {
+        res.status(404).send(e)
+      }
+    }
+  })
+
+  router.get(/^\/(.+)\/did.json$/, async (req: RequestWithAgentIdentityManager, res) => {
+    if (req.agent) {
+      try {
+        const identity = await req.agent.identityManagerGetIdentity({
+          did: 'did:web:' + req.hostname + ':' + req.params[0].replace('/', ':'),
+        })
+        const didDoc = didDocForIdentity(identity)
+        res.json(didDoc)
+      } catch (e) {
+        res.status(404).send(e)
+      }
+    }
+  })
 
   return router
 }

--- a/packages/daf-express/src/web-did-doc-router.ts
+++ b/packages/daf-express/src/web-did-doc-router.ts
@@ -1,7 +1,5 @@
 import { IAgent, IIdentity, IIdentityManager, TAgent } from 'daf-core'
-import { Request, Response, NextFunction, Router, json } from 'express'
-import { getOpenApiSchema } from 'daf-rest'
-import Debug from 'debug'
+import { Request, Router } from 'express'
 
 interface RequestWithAgentIdentityManager extends Request {
   agent?: TAgent<IIdentityManager>
@@ -15,7 +13,7 @@ export const didDocEndpoint = '/.well-known/did.json'
 /**
  * @public
  */
-export interface DidDocRouterOptions {
+export interface WebDidDocRouterOptions {
   /**
    * Function that returns configured agent for specific request
    */
@@ -27,7 +25,7 @@ export interface DidDocRouterOptions {
  * @param options - Initialization option
  * @returns Expressjs router
  */
-export const DidDocRouter = (options: DidDocRouterOptions): Router => {
+export const WebDidDocRouter = (options: WebDidDocRouterOptions): Router => {
   const router = Router()
   router.use(async (req: RequestWithAgent, res, next) => {
     req.agent = await options.getAgentForRequest(req)


### PR DESCRIPTION
# Setup

```typescript
import express from 'express'
import { agent } from './agent'
import { AgentRouter, ApiSchemaRouter, DidDocRouter } from 'daf-express'

const getAgentForRequest = async (req: express.Request) => agent
const exposedMethods = agent.availableMethods()
const basePath = '/agent'
const schemaPath = '/open-api.json'

const agentRouter = AgentRouter({
  getAgentForRequest,
  exposedMethods,
})

const schemaRouter = ApiSchemaRouter({
  basePath,
  getAgentForRequest,
  exposedMethods,
})

const didDocRouter = DidDocRouter({
  getAgentForRequest
})

const app = express()
app.use(basePath, agentRouter)
app.use(schemaPath, schemaRouter)
app.use(didDocRouter)
app.listen(3002)
```

# Usage

```typescript
// 'did:web:example.com'
const serverIdentity = await agent.identityManagerCreateIdentity({
  alias: 'example.com',
  provider: 'did:web',
})

// 'did:web:example.com:alice'
const alice = await agent.identityManagerCreateIdentity({
  alias: 'example.com:alice',
  provider: 'did:web',
})
```