### PR TITLE
fix(daf-did-jwt): Fix parsing of JWT with missing `typ` in header

### DIFF
--- a/packages/daf-core/package.json
+++ b/packages/daf-core/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",
-    "did-resolver": "2.1.1",
+    "did-resolver": "2.1.2",
     "typescript": "^4.0.3"
   },
   "files": [

--- a/packages/daf-core/plugin.schema.json
+++ b/packages/daf-core/plugin.schema.json
@@ -19,8 +19,21 @@
           "type": "object",
           "properties": {
             "@context": {
-              "type": "string",
-              "const": "https://w3id.org/did/v1"
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "https://w3id.org/did/v1"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
             },
             "id": {
               "type": "string"
@@ -34,7 +47,17 @@
             "authentication": {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/Authentication"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PublicKey"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Authentication"
+                  }
+                ]
               }
             },
             "uportProfile": {},

--- a/packages/daf-did-jwt/package.json
+++ b/packages/daf-did-jwt/package.json
@@ -12,8 +12,8 @@
     "daf-core": "^7.0.0-beta.55",
     "daf-message-handler": "^7.0.0-beta.55",
     "debug": "^4.1.1",
-    "did-jwt": "4.7.1",
-    "did-resolver": "2.1.1"
+    "did-jwt": "4.8.0",
+    "did-resolver": "2.1.2"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/packages/daf-did-jwt/src/__tests__/didkey.test.ts
+++ b/packages/daf-did-jwt/src/__tests__/didkey.test.ts
@@ -65,7 +65,7 @@ describe('daf-did-jwt', () => {
             type: ['VerifiableCredential', 'DomainLinkageCredential'],
           },
         },
-        metaData: [{ type: 'test' }, { type: undefined, value: 'EdDSA' }],
+        metaData: [{ type: 'test' }, { type: 'JWT', value: 'EdDSA' }],
       }),
       context,
     )

--- a/packages/daf-did-jwt/src/message-handler.ts
+++ b/packages/daf-did-jwt/src/message-handler.ts
@@ -19,7 +19,7 @@ export class JwtMessageHandler extends AbstractMessageHandler {
         const resolver = { resolve: (didUrl: string) => context.agent.resolveDid({ didUrl }) }
         const verified = await verifyJWT(message.raw, { resolver, audience })
         debug('Message.raw is a valid JWT')
-        message.addMetaData({ type: decoded.header.typ, value: decoded.header.alg })
+        message.addMetaData({ type: decoded.header.typ || 'JWT', value: decoded.header.alg })
         message.data = verified.payload
       } catch (e) {
         debug(e.message)

--- a/packages/daf-libsodium/package.json
+++ b/packages/daf-libsodium/package.json
@@ -13,7 +13,7 @@
     "daf-core": "^7.0.0-beta.55",
     "daf-key-manager": "^7.0.0-beta.55",
     "debug": "^4.1.1",
-    "did-jwt": "4.7.1",
+    "did-jwt": "4.8.0",
     "elliptic": "^6.5.2",
     "ethjs-signer": "^0.1.1",
     "libsodium-wrappers": "^0.7.6"

--- a/packages/daf-react-native-libsodium/package.json
+++ b/packages/daf-react-native-libsodium/package.json
@@ -13,7 +13,7 @@
     "daf-core": "^7.0.0-beta.55",
     "daf-key-manager": "^7.0.0-beta.55",
     "debug": "^4.1.1",
-    "did-jwt": "4.7.1",
+    "did-jwt": "4.8.0",
     "elliptic": "^6.5.2",
     "ethjs-signer": "^0.1.1"
   },

--- a/packages/daf-resolver-universal/package.json
+++ b/packages/daf-resolver-universal/package.json
@@ -12,7 +12,7 @@
     "cross-fetch": "^3.0.5",
     "daf-core": "^7.0.0-beta.55",
     "debug": "^4.1.1",
-    "did-resolver": "2.1.1"
+    "did-resolver": "2.1.2"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/packages/daf-resolver/package.json
+++ b/packages/daf-resolver/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "daf-core": "^7.0.0-beta.55",
     "debug": "^4.1.1",
-    "did-resolver": "2.1.1",
+    "did-resolver": "2.1.2",
     "ethr-did-resolver": "^3.0.0",
     "nacl-did": "^1.0.1",
     "web-did-resolver": "^1.3.3"

--- a/packages/daf-selective-disclosure/package.json
+++ b/packages/daf-selective-disclosure/package.json
@@ -21,7 +21,7 @@
     "daf-typeorm": "^7.0.0-beta.55",
     "daf-w3c": "^7.0.0-beta.55",
     "debug": "^4.1.1",
-    "did-jwt": "4.7.1"
+    "did-jwt": "4.8.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/packages/daf-w3c/package.json
+++ b/packages/daf-w3c/package.json
@@ -21,7 +21,7 @@
     "daf-resolver": "^7.0.0-beta.55",
     "debug": "^4.1.1",
     "did-jwt-vc": "^1.0.3",
-    "did-resolver": "2.1.1"
+    "did-resolver": "2.1.2"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/packages/tsconfig.settings.json
+++ b/packages/tsconfig.settings.json
@@ -3,7 +3,7 @@
     "strict": true,
     "preserveConstEnums": true,
     "sourceMap": true,
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6014,10 +6014,10 @@ did-jwt-vc@^1.0.3:
   dependencies:
     did-jwt "^4.4.2"
 
-did-jwt@4.7.1:
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-4.7.1.tgz#f340e4087a29385e08f1e750f88d746d4005ddd1"
-  integrity sha512-fQnNhQKmbNOiYIPEXxJMrSw5rLAiIsfJ6I9DX28ftsSxBDiMo7MARIzAn2V79/Bf/gI9UxIWrsyxLtuj6hd2kw==
+did-jwt@4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/did-jwt/-/did-jwt-4.8.0.tgz#b5d7727d264be52f5d576c6da38bee2cdc282199"
+  integrity sha512-7Vwv+E6st0lETniq8ygr3BFv0Af7YOATw31aIiHP3TxIJf79DHLeplI5aHQI36leh7S+cusdWlNxTxTdAPr9/A==
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@stablelib/ed25519" "^1.0.1"
@@ -6025,7 +6025,7 @@ did-jwt@4.7.1:
     "@stablelib/sha256" "^1.0.0"
     "@stablelib/x25519" "^1.0.0"
     "@stablelib/xchacha20poly1305" "^1.0.0"
-    did-resolver "^2.1.1"
+    did-resolver "^2.1.2"
     elliptic "^6.5.3"
     js-sha3 "^0.8.0"
     uint8arrays "^1.1.0"
@@ -6071,6 +6071,11 @@ did-resolver@2.1.1, did-resolver@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-2.1.1.tgz#43796f8a3e921644e5fb15a8147684ca87019cfd"
   integrity sha512-FYLTkNWofjYNDGV1HTQlyVu1OqZiFxR4I8KM+oxGVOkbXva15NfWzbzciqdXUDqOhe6so5aroAdrVip6gSAYSA==
+
+did-resolver@2.1.2, did-resolver@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/did-resolver/-/did-resolver-2.1.2.tgz#f1194fdbc087161809ce545e13c11a596f4a3928"
+  integrity sha512-n4YGS1CzbX48U/ChLRY3SdgiV5N3B/+yh0ToS5t+Sx4QjhVZN6ZyijUSSYbFGvz+I4qImeSZOdo6RX8JaieN7A==
 
 did-resolver@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
`JwtMessageHandler` can parse them but they fail later in the the message handler chain if `typ` is missing.

Also, this fixes #291